### PR TITLE
put JS code to src/js dir; Windows instructions

### DIFF
--- a/{{cookiecutter.directory_name}}/README.md
+++ b/{{cookiecutter.directory_name}}/README.md
@@ -17,7 +17,7 @@ pt deploy build/distributions/*-upgrade.zip
 ### Dev mode
 The most convenient dev env for plugins is via [Browsersync](https://github.com/egis/build-tools/#browsersync). 
 To set this up,
-* in one terminal window run `cd MyProject && npm run dev`
-* in another terminal window run `cd build-tools && npm run browsersync -- --plugin=MyProject`
+* in one terminal window run `cd {{cookiecutter.name}} && npm run dev`
+* in another terminal window run `cd build-tools && npm run browsersync -- --plugin={{cookiecutter.name}}`
 
 Normal standalone `npm run dev` dev env works too.

--- a/{{cookiecutter.directory_name}}/README.md
+++ b/{{cookiecutter.directory_name}}/README.md
@@ -21,3 +21,19 @@ To set this up,
 * in another terminal window run `cd build-tools && npm run browsersync -- --plugin={{cookiecutter.name}}`
 
 Normal standalone `npm run dev` dev env works too.
+
+#### Windows development env
+* download and install nvm in c:\app\nvm (better not default Program Files dirs to avoid spaces in its path)
+* download and install Python 2.7, add it to PATH
+* if you're on windows 7 or Vista, install .net framework 4.5.1
+* install Node 6 (because it's easier to make work with gyp & fibers)
+* `nvm install 6.0.0` # or `nvm install 6.0.0 32` if you're on 32bit windows  
+* `nvm use 6.0.0` # or `nvm use 6.0.0 32` if you're on 32bit windows  
+* git clone the project # I couldn't make cookiecutter work on Windows yet
+* put this instead of existing `setup` and `update` scripts of the project's package.json:  
+```
+    "setup": "npm install && npm run update",
+    "update": "sh node_modules/@egis/build-tools/npm-install.sh",
+```
+* `cd {{cookiecutter.name}}`
+Then you can use usual dev commands like `gradle setup` and `npm run dev`, including browsersync support.

--- a/{{cookiecutter.directory_name}}/src/.dev-loader.js
+++ b/{{cookiecutter.directory_name}}/src/.dev-loader.js
@@ -8,7 +8,7 @@ window[moduleName] = (function() {
 
     var p = new Promise( function (resolve) {
         EgisUI.loaded(function() {
-            console.log('Loading ' + moduleName + ' plugin with SystemJS..', EgisUI.currentTimeWithMillisString());
+            log.info('Loading ' + moduleName + ' plugin with SystemJS..', EgisUI.currentTimeWithMillisString());
             var map = {};
             map[moduleName] = 'http://HOST:PORT/dist/main/dev-index';
             System.config({
@@ -20,7 +20,7 @@ window[moduleName] = (function() {
                 _.forEach(m, function(value, key) {
                     moduleProxy[key] = value;
                 });
-                console.log(moduleName + ' plugin loaded in', new Date().getTime() - d0, EgisUI.currentTimeWithMillisString());
+                log.info(moduleName + ' plugin loaded in', new Date().getTime() - d0, EgisUI.currentTimeWithMillisString());
                 resolve(m);
             });
         });

--- a/{{cookiecutter.directory_name}}/src/.lib-exports.js
+++ b/{{cookiecutter.directory_name}}/src/.lib-exports.js
@@ -9,4 +9,4 @@ export {
 };
 
 //pick the files code
-import './{{cookiecutter.name}}Customization';
+import './js/{{cookiecutter.name}}Customization';

--- a/{{cookiecutter.directory_name}}/src/js/{{cookiecutter.name}}Customization.js
+++ b/{{cookiecutter.directory_name}}/src/js/{{cookiecutter.name}}Customization.js
@@ -28,7 +28,7 @@ export default class {{cookiecutter.name}}Customization {
 }
 
 UI.plugin(() => {
-    console.log('Loading {{cookiecutter.name}} plugin @@version @@timestamp');
+    log.info('Loading {{cookiecutter.name}} plugin @@version @@timestamp');
 
     window.customization = new {{cookiecutter.name}}Customization();
 });


### PR DESCRIPTION
This works fine with `"build": { "autoImportAll": false }` so I kept it - but we better remove it manually for existing projects' updates.

Also entry point JS files, `.dev-loader.js` and `.lib-exports.js` are kept in `src` dir for now - I'll move them later, need to teach build-tools first to use `src/js` dir for plugins.

re Windows development, I've checked and confirmed that it works with Node 6 (couldn't make it work with higher versions though due to issues with `node-sass` package - maybe with my specific env) if we change package.json to non-yaml mode - provided instructions for that in this PR.